### PR TITLE
ChatGPT 웹페이지 내 sideBar가 존재하지 않을 경우 form 요소가 추가되지 않는 버그 수정

### DIFF
--- a/utils/chat.js
+++ b/utils/chat.js
@@ -67,7 +67,7 @@ if (!window.utils.chat) {
 
   const initializeChatElements = async () => {
     const chatElements = document.querySelectorAll(
-      'div.mx-auto.flex.flex-1.gap-4.text-base.md\\:gap-5.lg\\:gap-6.md\\:max-w-3xl.lg\\:max-w-\\[40rem\\].xl\\:max-w-\\[48rem\\]',
+      'div.mx-auto.flex.flex-1.text-base.gap-4.md\\:gap-5.lg\\:gap-6',
     );
 
     const results = await Promise.all(


### PR DESCRIPTION
- sideBar가 ChatGPT 웹페이지에 존재하지 않더라도 정상적으로 작동함
- Form 후보 요소를 선택하는 `querySelectAll()`의 범위를 sideBar가 존재하지 않을 때까지 선택되도록 넓힘